### PR TITLE
Fix/submenu rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,5 @@
   },
   "keywords": [],
   "author": "Jeff Zucker",
-  "license": "MIT",
+  "license": "MIT"
 }

--- a/src/menu-dropdown.css
+++ b/src/menu-dropdown.css
@@ -37,7 +37,7 @@ button.selected, button:hover {
   margin-right:0.75em;
 }
 .solid-uic-dropdown-menu ul li:hover > ul {
-  display:inherit;
+  display:block;
 }
 .solid-uic-dropdown-menu ul ul li {
   width:230px;


### PR DESCRIPTION
Fixes submenu rendering on Firefox.  Tested operation of Chromium on Brave and that still works.

Also fixed the package.json.  It contained a trailing `,` which is not allowed in JSON files.  I'm unsure if all versions of npm barf on this.