### PR TITLE
Feature/host from local filesystem

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html><html><head>
   <meta content="text/html; charset=UTF-8" http-equiv="content-type">
-  <link rel="stylesheet" href="/solid-ui-components/src/modalButton.css">
-  <link rel="stylesheet" href="/solid-ui-components/src/menu-dropdown.css">
+  <link rel="stylesheet" href="./src/modalButton.css">
+  <link rel="stylesheet" href="./src/menu-dropdown.css">
   <script src="https://solidcommunity.net/mashlib.js"></script>
-  <script src="/solid-ui-components/src/menu.js"></script>
-  <script src="/solid-ui-components/src/solid-ui-components.js"></script>
+  <script src="./src/menu.js"></script>
+  <script src="./src/solid-ui-components.js"></script>
   <script src="https://rdf.js.org/comunica-browser/versions/1/packages/actor-init-sparql/comunica-browser.js"></script>
   <style>
     pre {font-size:small;}


### PR DESCRIPTION
Use relative paths for local sources in demo.html

By using relative paths in demo.html, we can visit the demo.html using `file:///home/user/path/to/sources/demo.html` and view the demo interactively without any servers.

Helped me in making the other PR, might as well share.  Tested if it still runs on GitHub pages at https://madnificent.github.io/solid-ui-components/demo.html
